### PR TITLE
fix: make offers with amounts from dapps work

### DIFF
--- a/src/util/WalletBackendAdapter.ts
+++ b/src/util/WalletBackendAdapter.ts
@@ -17,7 +17,7 @@ import { getDappService } from '../service/Dapps';
 import { getIssuerService } from '../service/Issuers';
 import { getOfferService } from '../service/Offers';
 
-import type { Amount, Brand, DisplayInfo } from '@agoric/ertp/src/types';
+import type { Brand, DisplayInfo } from '@agoric/ertp/src/types';
 import type { Notifier } from '@agoric/notifier/src/types';
 import type { OfferStatus } from '@agoric/smart-wallet/src/offers';
 import type { UpdateRecord } from '@agoric/smart-wallet/src/smartWallet';
@@ -183,7 +183,7 @@ export const makeWalletBridgeFromFollowers = (
     // wallet chainstorage.
     if (!isOfferServiceStarted && isBankLoaded && isSmartWalletLoaded) {
       isOfferServiceStarted = true;
-      offerService.start(pursePetnameToBrand);
+      offerService.start(pursePetnameToBrand, brandToPurse);
     }
   };
 


### PR DESCRIPTION
Tested locally with dapp-inter.

This lets dapps send amounts in offer proposals rather than pursePetnames+values now that purses are lazily instantiated from offers. Also fixes an issue where dapps couldn't use BigInts in offers since localstorage couldn't serialize raw BigInts. The serialized CapData amount can be written to localstorage just fine.