### PR TITLE
feat: allow exiting offers

### DIFF
--- a/wallet/src/bridge-dapp.tsx
+++ b/wallet/src/bridge-dapp.tsx
@@ -81,10 +81,6 @@ const createAndAddOffer = (dappKey: DappKey, offerConfig: OfferConfig) => {
 
   const offer = {
     id,
-    meta: {
-      id,
-      creationStamp: currentTime,
-    },
     requestContext: { origin: dappKey.origin },
     status: OfferUIStatus.proposed,
     ...offerConfig,

--- a/wallet/src/components/Offer.scss
+++ b/wallet/src/components/Offer.scss
@@ -1,9 +1,3 @@
-.Date {
-  float: right;
-  font-size: 16px;
-  line-height: 32px;
-}
-
 .Blue {
   color: rgb(0, 176, 255);
 }

--- a/wallet/src/components/Offer.tsx
+++ b/wallet/src/components/Offer.tsx
@@ -5,20 +5,17 @@ import CloseIcon from '@mui/icons-material/Close';
 import { useState } from 'react';
 import Request from './Request';
 import PetnameSpan from './PetnameSpan';
-import { formatDateNow } from '../util/Date';
 import { withApplicationContext } from '../contexts/Application';
 import ErrorBoundary from './ErrorBoundary';
 import Proposal from './Proposal';
 
 import './Offer.scss';
 
-// XXX this isn't implemented yet so hide the button.
-const ALLOW_EXIT_OFFER = false;
-
 const statusText = {
   decline: 'Declined',
   rejected: 'Rejected',
   accept: 'Accepted',
+  refunded: 'Refunded',
   complete: 'Accepted',
   pending: 'Pending',
   proposed: 'Proposed',
@@ -27,6 +24,7 @@ const statusText = {
 
 const statusColors = {
   accept: 'success',
+  refunded: 'error',
   rejected: 'error',
   decline: 'error',
   pending: 'warning',
@@ -49,9 +47,9 @@ const OfferWithoutContext = ({
 
   const {
     sourceDescription,
-    requestContext: { dappOrigin = undefined, origin = 'unknown origin' } = {},
+    requestContext: { dappOrigin = undefined, origin = undefined } = {},
     id,
-    meta: { creationStamp: date },
+    isSeated,
   } = offer;
   let status = offer.status || 'proposed';
 
@@ -95,7 +93,7 @@ const OfferWithoutContext = ({
 
   const controls = (
     <div className="Controls">
-      {ALLOW_EXIT_OFFER && status === 'pending' && (
+      {isSeated && (
         <Chip
           onClick={exit}
           variant="outlined"
@@ -130,8 +128,8 @@ const OfferWithoutContext = ({
     'accept',
     'decline',
     'complete',
-    'rejected',
     'cancel',
+    'refunded',
   ].includes(status);
 
   return (
@@ -141,11 +139,14 @@ const OfferWithoutContext = ({
         color={statusColors[status]}
         label={statusText[status]}
       />
-      <span className="Date text-gray">{formatDateNow(date)}</span>
       <div className="OfferOrigin" style={{ wordBreak: 'break-word' }}>
         <PetnameSpan name={sourceDescription} />
-        <i> via </i>
-        <span className="Blue">{dappOrigin || origin}</span>
+        {(dappOrigin || origin) && (
+          <>
+            <i> via </i>
+            <span className="Blue">{dappOrigin || origin}</span>
+          </>
+        )}
       </div>
       <ErrorBoundary>
         <Proposal

--- a/wallet/src/components/Offer.tsx
+++ b/wallet/src/components/Offer.tsx
@@ -52,6 +52,7 @@ const OfferWithoutContext = ({
     isSeated,
   } = offer;
   let status = offer.status || 'proposed';
+  const actualOrigin = dappOrigin || origin;
 
   // Update context if component was rendered while pending.
   if (status === 'pending' && !pendingOffers.has(id)) {
@@ -136,10 +137,10 @@ const OfferWithoutContext = ({
       />
       <div className="OfferOrigin" style={{ wordBreak: 'break-word' }}>
         <PetnameSpan name={sourceDescription} />
-        {(dappOrigin || origin) && (
+        {actualOrigin && (
           <>
             <i> via </i>
-            <span className="Blue">{dappOrigin || origin}</span>
+            <span className="Blue">{actualOrigin}</span>
           </>
         )}
       </div>

--- a/wallet/src/components/Offer.tsx
+++ b/wallet/src/components/Offer.tsx
@@ -82,7 +82,7 @@ const OfferWithoutContext = ({
   };
 
   const exit = () => {
-    offer.actions.cancel().catch(console.error);
+    offer.actions.tryExit().catch(console.error);
   };
 
   const close = () => {

--- a/wallet/src/components/Offer.tsx
+++ b/wallet/src/components/Offer.tsx
@@ -124,13 +124,8 @@ const OfferWithoutContext = ({
     </div>
   );
 
-  const isOfferCompleted = [
-    'accept',
-    'decline',
-    'complete',
-    'cancel',
-    'refunded',
-  ].includes(status);
+  const isOfferCompleted =
+    !['proposed', 'pending'].includes(status) && !isSeated;
 
   return (
     <Request header="Offer" completed={isOfferCompleted} close={close}>

--- a/wallet/src/components/Proposal.tsx
+++ b/wallet/src/components/Proposal.tsx
@@ -9,9 +9,10 @@ import PurseValue from './PurseValue';
 import { formatDateNow } from '../util/Date';
 import { withApplicationContext } from '../contexts/Application';
 import BrandIcon from './BrandIcon';
+import { stringify } from '../util/marshal';
+import { Typography } from '@mui/material';
 
 import './Offer.scss';
-import { Typography } from '@mui/material';
 
 const OfferEntryFromTemplate = (
   type,
@@ -193,6 +194,7 @@ const Proposal = ({ offer, purses, swingsetParams, beansOwing }) => {
     } = {},
     error,
     spendAction,
+    offerArgs,
   } = offer;
   let give = {};
   let want = {};
@@ -254,10 +256,12 @@ const Proposal = ({ offer, purses, swingsetParams, beansOwing }) => {
           </div>
         </div>
       )}
-      {args !== undefined && (
+      {offerArgs !== undefined && (
         <div className="OfferEntry">
           <h6>Arguments</h6>
-          <pre>{JSON.stringify(args, null, 2)}</pre>
+          <details style={{ whiteSpace: 'pre-wrap' }}>
+            {stringify(offerArgs, true)}
+          </details>
         </div>
       )}
       <ExecutionFeeInfo

--- a/wallet/src/components/tests/Offer.test.jsx
+++ b/wallet/src/components/tests/Offer.test.jsx
@@ -332,18 +332,18 @@ test('declines the offer', () => {
 });
 
 test('cancels the offer', () => {
-  const cancel = jest.fn(() => Promise.resolve());
+  const tryExit = jest.fn(() => Promise.resolve());
   const pendingOffer = {
     ...offer,
     isSeated: true,
     status: 'pending',
-    actions: { cancel },
+    actions: { tryExit },
   };
   const component = mount(<Offer offer={pendingOffer} />);
 
   act(() => component.find(Chip).at(1).props().onClick());
 
-  expect(cancel).toHaveBeenCalledWith();
+  expect(tryExit).toHaveBeenCalledWith();
 });
 
 test('renders the dapp origin', () => {

--- a/wallet/src/components/tests/Offer.test.jsx
+++ b/wallet/src/components/tests/Offer.test.jsx
@@ -79,9 +79,6 @@ const offer = {
     dappOrigin: 'https://tokenpalace.app',
     origin: 'unknown origin',
   },
-  meta: {
-    creationStamp: 1636614038901,
-  },
   proposalForDisplay: {
     arguments: [],
     give: {
@@ -181,14 +178,6 @@ test('renders the arguments', () => {
   expect(args.text()).toContain('Arguments');
   expect(args.text()).toContain(
     JSON.stringify(offer.proposalForDisplay.arguments, null, 2),
-  );
-});
-
-test('renders the timestamp', () => {
-  const component = mount(<Offer offer={offer} />);
-
-  expect(component.find('.Date').text()).toContain(
-    formatDateNow(offer.meta.creationStamp),
   );
 });
 

--- a/wallet/src/components/tests/Offer.test.jsx
+++ b/wallet/src/components/tests/Offer.test.jsx
@@ -264,6 +264,9 @@ test('renders the request as completed when appropriate', () => {
   const rejectedOffer = { ...offer };
   rejectedOffer.status = 'rejected';
   component = mount(<Offer offer={rejectedOffer} />);
+  expect(component.find(Request).props().completed).toEqual(true);
+  rejectedOffer.isSeated = true;
+  component = mount(<Offer offer={rejectedOffer} />);
   expect(component.find(Request).props().completed).toEqual(false);
 
   const cancelledOffer = { ...offer };

--- a/wallet/src/components/tests/Offer.test.jsx
+++ b/wallet/src/components/tests/Offer.test.jsx
@@ -31,6 +31,8 @@ jest.mock(
 
 jest.mock('../../util/Date', () => ({ formatDateNow: stamp => String(stamp) }));
 jest.mock('@mui/material/Popover', () => ({ children }) => <>{children}</>);
+jest.mock('../../util/marshal', () => ({ stringify: () => 'some string' }));
+
 const pendingOffers = new Set();
 const setPendingOffers = jest.fn();
 const declinedOffers = new Set();
@@ -78,8 +80,8 @@ const offer = {
     dappOrigin: 'https://tokenpalace.app',
     origin: 'unknown origin',
   },
+  offerArgs: { foo: 'bar' },
   proposalForDisplay: {
-    arguments: [],
     give: {
       Collateral: {
         amount: {
@@ -176,9 +178,7 @@ test('renders the arguments', () => {
   const args = component.find('.OfferEntry').at(4);
 
   expect(args.text()).toContain('Arguments');
-  expect(args.text()).toContain(
-    JSON.stringify(offer.proposalForDisplay.arguments, null, 2),
-  );
+  expect(args.text()).toContain('some string');
 });
 
 test('renders the controls', () => {

--- a/wallet/src/contexts/Provider.tsx
+++ b/wallet/src/contexts/Provider.tsx
@@ -61,7 +61,6 @@ const inboxReducer = (_, newInbox) => {
       ?.map(tx => ({
         ...tx,
         offerId: tx.id,
-        id: tx.meta.id,
       }))
       .sort((a, b) => a.id - b.id) || null
   );

--- a/wallet/src/service/Offers.ts
+++ b/wallet/src/service/Offers.ts
@@ -273,7 +273,8 @@ export const getOfferService = (
       pendingOffersNotifier,
     )) {
       console.log('pending offers', pendingOffers);
-      pendingOffers?.forEach(([_, o]) => {
+      if (!pendingOffers) continue;
+      for (const [_, o] of pendingOffers) {
         const { id } = o;
         const oldOffer = offers.get(id);
         if (!oldOffer) {
@@ -299,7 +300,7 @@ export const getOfferService = (
             isSeated: true,
           });
         }
-      });
+      }
       broadcastUpdates();
     }
   };

--- a/wallet/src/service/Offers.ts
+++ b/wallet/src/service/Offers.ts
@@ -238,7 +238,7 @@ export const getOfferService = (
                 ? OfferUIStatus.refunded
                 : OfferUIStatus.accepted,
             isSeated: false,
-            error: `${status.error}`,
+            error: status.error && `${status.error}`,
           });
           remove(smartWalletKey, id);
         } else if (status.error !== undefined) {

--- a/wallet/src/service/Offers.ts
+++ b/wallet/src/service/Offers.ts
@@ -208,7 +208,7 @@ export const getOfferService = (
     return signSpendAction(offer.spendAction);
   };
 
-  const cancelOffer = async (id: number) => {
+  const tryExitOffer = async (id: number) => {
     const action = await E(boardIdMarshaller).serialize(
       harden({
         method: 'tryExitOffer',
@@ -273,7 +273,7 @@ export const getOfferService = (
       pendingOffersNotifier,
     )) {
       console.log('pending offers', pendingOffers);
-      pendingOffers.forEach(([_, o]) => {
+      pendingOffers?.forEach(([_, o]) => {
         const id = Number(o.id);
         const oldOffer = offers.get(id);
         if (!oldOffer) {
@@ -362,7 +362,7 @@ export const getOfferService = (
     notifier,
     addOffer: upsertOffer,
     acceptOffer,
-    cancelOffer,
+    tryExitOffer,
     declineOffer,
   };
 };

--- a/wallet/src/service/Offers.ts
+++ b/wallet/src/service/Offers.ts
@@ -224,7 +224,7 @@ export const getOfferService = (
       offerUpdatesNotifier,
     )) {
       console.log('offerStatus', { status, offers });
-      const id = status && Number(status?.id);
+      const id = status?.id;
       const oldOffer = offers.get(id);
       if (!oldOffer) {
         console.warn('Update for unknown offer, doing nothing.');
@@ -274,14 +274,18 @@ export const getOfferService = (
     )) {
       console.log('pending offers', pendingOffers);
       pendingOffers?.forEach(([_, o]) => {
-        const id = Number(o.id);
+        const { id } = o;
         const oldOffer = offers.get(id);
         if (!oldOffer) {
           offers.set(id, {
             ...o,
             proposalTemplate: {
-              give: makeProposalEntriesDisplayable(o.proposal.give),
-              want: makeProposalEntriesDisplayable(o.proposal.want),
+              give:
+                o.proposal.give &&
+                makeProposalEntriesDisplayable(o.proposal.give),
+              want:
+                o.proposal.want &&
+                makeProposalEntriesDisplayable(o.proposal.want),
             },
             sourceDescription:
               'Source: ' + sourceDescriptionForSpec(o.invitationSpec),

--- a/wallet/src/service/Offers.ts
+++ b/wallet/src/service/Offers.ts
@@ -273,7 +273,7 @@ export const getOfferService = (
       pendingOffersNotifier,
     )) {
       console.log('pending offers', pendingOffers);
-      Object.values(pendingOffers).forEach((o: any) => {
+      pendingOffers.forEach(([_, o]) => {
         const id = Number(o.id);
         const oldOffer = offers.get(id);
         if (!oldOffer) {

--- a/wallet/src/service/Offers.ts
+++ b/wallet/src/service/Offers.ts
@@ -247,8 +247,10 @@ export const getOfferService = (
             id,
             status: OfferUIStatus.rejected,
             error: `${status.error}`,
-            isSeated: true,
           });
+          if (!oldOffer.isSeated) {
+            remove(smartWalletKey, id);
+          }
         }
         broadcastUpdates();
       }

--- a/wallet/src/store/Offers.ts
+++ b/wallet/src/store/Offers.ts
@@ -12,15 +12,12 @@ export enum OfferUIStatus {
   rejected = 'rejected',
   pending = 'pending',
   declined = 'decline',
+  refunded = 'refunded',
 }
 
 import { OfferConfig } from '@agoric/web-components/src/dapp-wallet-bridge/DappWalletBridge';
 export type Offer = {
   id: number;
-  meta: {
-    id: number;
-    creationStamp: number;
-  };
   requestContext: {
     origin: string;
   };

--- a/wallet/src/util/WalletBackendAdapter.ts
+++ b/wallet/src/util/WalletBackendAdapter.ts
@@ -66,7 +66,7 @@ export const makeBackendFromWalletBridge = (
                   // Provide these synthetic actions since offers don't have any yet.
                   accept: () => E(walletBridge).acceptOffer(id),
                   decline: () => E(walletBridge).declineOffer(id),
-                  cancel: () => E(walletBridge).cancelOffer(id),
+                  tryExit: () => E(walletBridge).tryExitOffer(id),
                 },
               }),
             ),
@@ -301,9 +301,7 @@ export const makeWalletBridgeFromFollowers = (
     for await (const { value } of iterateLatest<{ value: any }>(
       currentFollower,
     )) {
-      notifierKits.pendingOffers.updater.updateState(
-        value.possiblyExitableOffers,
-      );
+      notifierKits.pendingOffers.updater.updateState(value.liveOffers);
     }
   };
 
@@ -433,7 +431,7 @@ export const makeWalletBridgeFromFollowers = (
 
   const issuerService = getIssuerService(signSpendAction);
   const dappService = getDappService(smartWalletKey);
-  const { acceptOffer, declineOffer, cancelOffer } = offerService;
+  const { acceptOffer, declineOffer, tryExitOffer } = offerService;
 
   const {
     getContactsNotifier,
@@ -457,7 +455,7 @@ export const makeWalletBridgeFromFollowers = (
     getPursesNotifier,
     acceptOffer,
     declineOffer,
-    cancelOffer,
+    tryExitOffer,
     makeEmptyPurse,
     addContact,
     addIssuer,

--- a/wallet/src/util/WalletBackendAdapter.ts
+++ b/wallet/src/util/WalletBackendAdapter.ts
@@ -301,6 +301,7 @@ export const makeWalletBridgeFromFollowers = (
     for await (const { value } of iterateLatest<{ value: any }>(
       currentFollower,
     )) {
+      console.debug('current', value);
       notifierKits.pendingOffers.updater.updateState(value.liveOffers);
     }
   };


### PR DESCRIPTION
fixes: https://github.com/Agoric/wallet-app/issues/61

- Adds exit button to currently-seated offers
- Adds refunded status for offers with 0 wants satisfied

Tested making liquidation bids from CLI and exiting them from UI

![image](https://user-images.githubusercontent.com/8848650/220493459-644cb613-d098-417d-96c8-65917e22b9a0.png)

![image](https://user-images.githubusercontent.com/8848650/220493487-6de58d73-7474-4856-965f-1ea19a3e965e.png)
