### PR TITLE
fix: display args as monospace

### DIFF
--- a/wallet/src/components/Proposal.tsx
+++ b/wallet/src/components/Proposal.tsx
@@ -260,7 +260,9 @@ const Proposal = ({ offer, purses, swingsetParams, beansOwing }) => {
         <div className="OfferEntry">
           <h6>Arguments</h6>
           <details style={{ whiteSpace: 'pre-wrap' }}>
-            {stringify(offerArgs, true)}
+            <Box sx={{ fontFamily: '"RobotoMono", monospace' }}>
+              {stringify(offerArgs, true)}
+            </Box>
           </details>
         </div>
       )}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8848650/228424897-bc8d89b2-7ade-4856-aeca-a63b9093cd9c.png)
