### PR TITLE
fix: avoid error in provision pool calculation

### DIFF
--- a/wallet/src/components/ProvisionDialog.tsx
+++ b/wallet/src/components/ProvisionDialog.tsx
@@ -30,6 +30,10 @@ const MINIMUM_PROVISION_POOL_BALANCE = 100n * 1_000_000n;
 
 const isProvisionPoolLow = provisionPoolData =>
   provisionPoolData &&
+  AmountMath.isGTE(
+    provisionPoolData.totalMintedConverted,
+    provisionPoolData.totalMintedProvided,
+  ) &&
   AmountMath.subtract(
     provisionPoolData.totalMintedConverted,
     provisionPoolData.totalMintedProvided,


### PR DESCRIPTION
If the provision pool is funded directly with IST rather than converting via the PSM, `totalMintedProvided` could be higher than `totalMintedConverted` and the subtraction could throw. It's probably better to read the IST balance directly rather than inferring this way, but the pool address isn't published anywhere currently, so for now just make sure it doesn't crash in this case.