### PR TITLE
fix: third-party cookies error

### DIFF
--- a/wallet/src/bridge-dapp.tsx
+++ b/wallet/src/bridge-dapp.tsx
@@ -153,6 +153,9 @@ const handleIncomingMessages = () => {
 };
 
 const connectDapp = async () => {
+  if (!('localStorage' in window)) {
+    throw new Error('No access to localStorage');
+  }
   checkParentWindow();
   handleIncomingMessages();
   sendMessage({
@@ -160,29 +163,16 @@ const connectDapp = async () => {
   });
 };
 
-const sendCookiesDisabledError = () => {
+const sendAccessError = (err: Error) => {
   sendMessage({
     type: BridgeProtocol.error,
-    message: 'Please enable cross-site cookies to use this functionality.',
+    message: err.message,
   });
 };
 
 const Bridge = () => {
   useEffect(() => {
-    const tryConnect = async () => {
-      if ('requestStorageAccess' in document) {
-        if (await document.hasStorageAccess()) {
-          return connectDapp();
-        } else {
-          sendCookiesDisabledError();
-        }
-      } else if ('localStorage' in window) {
-        return connectDapp();
-      } else {
-        sendCookiesDisabledError();
-      }
-    };
-    void tryConnect();
+    connectDapp().catch(sendAccessError);
   }, []);
 
   return <></>;


### PR DESCRIPTION
# Description

https://github.com/Agoric/dapp-psm/issues/69 seems to be due to the Bridge connection logic.

# Test Plan

1. open https://fix-cookies-error.wallet-app.pages.dev/wallet/ in one tab
2. open https://main.dapp-psm.pages.dev/?wallet=fix-cookies-error
3. disable Shields or Tracking Protection for PSM  site
4. click to Connect Keplr
5. in wallet click to Approve Dapp
5. in PSM verify "Successfully connected"

- [x] Firefox without TP
- [x] Brave without Shields
- [x] ~Firefox without TP~ fails silently
- [x] ~Brave without Shields~ fails silently
- [x] Chrome with Third-Party cookies allowed and First-Party Sets disabled
- [x] Chrome with Third-Party cookies allowed and First-Party Sets enabled (chrome://flags/#enable-first-party-sets) 
- [x] ~Chrome with Third-Party cookies blocked~ fails loudly with error in console "failed to read `localStorage` property from window)
