### PR TITLE
fix: read beansOwing correctly

### DIFF
--- a/wallet/src/rpc/src/batchQuery.ts
+++ b/wallet/src/rpc/src/batchQuery.ts
@@ -66,13 +66,19 @@ export const batchVstorageQuery = (
           }
 
           const value = JSON.parse(data.value);
+          const latestValueStr = Object.hasOwn(value, 'values')
+            ? value.values[value.values.length - 1]
+            : value;
+          const parsed = JSON.parse(latestValueStr);
+          const unserialized = Object.hasOwn(parsed, 'slots')
+            ? unserialize(parsed)
+            : parsed;
 
-          const latestValueStr = value.values[value.values.length - 1];
           return [
             pathToKey(paths[index]),
             {
               blockHeight: value.blockHeight,
-              value: unserialize(JSON.parse(latestValueStr)),
+              value: unserialized,
             },
           ];
         }),

--- a/wallet/src/util/WalletBackendAdapter.ts
+++ b/wallet/src/util/WalletBackendAdapter.ts
@@ -229,9 +229,14 @@ export const makeWalletBridgeFromFollowers = (
       watcher.watchLatest(
         [
           AgoricChainStoragePathKind.Data,
-          `published.beansOwing.${smartWalletKey.address}`,
+          `beansOwing.${smartWalletKey.address}`,
         ],
-        value => beansOwingUpdater.updateState(Number(value)),
+        value => {
+          beansOwingUpdater.updateState(Number(value));
+        },
+        err => {
+          console.error('error watching beansOwing', err);
+        },
       ),
     );
   };
@@ -309,7 +314,7 @@ export const makeWalletBridgeFromFollowers = (
       );
     });
 
-  const watchPendingOffers = async () => {
+  const watchPendingOffers = () => {
     stopWatchingHooks.push(
       watcher.watchLatest<Partial<CurrentWalletRecord>>(
         [
@@ -328,8 +333,8 @@ export const makeWalletBridgeFromFollowers = (
   const fetchCurrent = async () => {
     const resolvedFollower = await currentFollower;
     await assertHasData(resolvedFollower);
-    void watchBeansOwing();
-    void watchPendingOffers();
+    watchBeansOwing();
+    watchPendingOffers();
     watchChainBalances();
 
     const latestIterable = await E(resolvedFollower).getLatestIterable();


### PR DESCRIPTION
"Current Fees Accumulated" was always showing 0 because the query was failing silently. Fixed by using the correct vstorage path, and parsing the response correctly:
![image](https://github.com/Agoric/wallet-app/assets/8848650/10b671ac-080f-432a-b23d-aacf5ee48b84)
