### PR TITLE
feat: add node selectors to connection settings

### DIFF
--- a/wallet/src/components/ConnectionSettingsDialog.tsx
+++ b/wallet/src/components/ConnectionSettingsDialog.tsx
@@ -65,8 +65,8 @@ const useNodeSuggestions = (networkConfigHref: string) => {
       const networkConfig = await res.json();
 
       if (didConfigChange) return;
-      setApiSuggestions(networkConfig.apiAddrs);
-      setRpcSuggestions(networkConfig.rpcAddrs);
+      setApiSuggestions(networkConfig.apiAddrs ?? []);
+      setRpcSuggestions(networkConfig.rpcAddrs ?? []);
     };
 
     updateSuggestions().catch(() =>
@@ -167,10 +167,10 @@ const ConnectionSettingsDialog = ({
               case 'devnet':
                 setConfig({
                   ...config,
-                  href: `https://${value}.agoric.net/network-config`,
+                  href: networkConfigUrl.fromSource(value),
                 });
                 break;
-              case 'localhost':
+              case 'local':
                 setConfig({
                   ...config,
                   href: `${window.location.origin}/wallet/network-config`,
@@ -185,7 +185,7 @@ const ConnectionSettingsDialog = ({
           <MenuItem value="main">Mainnet</MenuItem>
           <MenuItem value="testnet">Testnet</MenuItem>
           <MenuItem value="devnet">Devnet</MenuItem>
-          <MenuItem value="localhost">Localhost</MenuItem>
+          <MenuItem value="local">Local</MenuItem>
           <MenuItem value="custom">
             <i>Custom URL</i>
           </MenuItem>

--- a/wallet/src/components/ConnectionSettingsDialog.tsx
+++ b/wallet/src/components/ConnectionSettingsDialog.tsx
@@ -183,7 +183,7 @@ const ConnectionSettingsDialog = ({
           }}
         >
           <MenuItem value="main">Mainnet</MenuItem>
-          <MenuItem value="testnet">Testnet</MenuItem>
+          <MenuItem value="testnet">Emerynet</MenuItem>
           <MenuItem value="devnet">Devnet</MenuItem>
           <MenuItem value="local">Local</MenuItem>
           <MenuItem value="custom">

--- a/wallet/src/components/tests/ConnectionSettingsDialog.test.tsx
+++ b/wallet/src/components/tests/ConnectionSettingsDialog.test.tsx
@@ -59,9 +59,7 @@ describe('Connection setting dialog', () => {
     );
 
     const networkSelect = component.find(Select).first();
-    act(() =>
-      networkSelect.props().onChange({ target: { value: 'localhost' } }),
-    );
+    act(() => networkSelect.props().onChange({ target: { value: 'local' } }));
     component.update();
 
     const textField = component.find(TextField).first();

--- a/wallet/src/contexts/Provider.tsx
+++ b/wallet/src/contexts/Provider.tsx
@@ -33,6 +33,7 @@ export type KeplrUtils = {
     interactiveSigner: InteractiveSigner;
     backgroundSigner: BackgroundSigner;
   };
+  rpc: string;
 };
 
 const useDebugLogging = (state, watch) => {
@@ -212,7 +213,7 @@ const Provider = ({ children }) => {
     assert(keplr, 'Missing window.keplr');
     const { getBytes } = Random;
 
-    const chainInfo = await suggestChain(connectionConfig.href, {
+    const chainInfo = await suggestChain(connectionConfig, {
       fetch,
       keplr,
       random: Math.random,
@@ -236,7 +237,6 @@ const Provider = ({ children }) => {
       address: accounts[0]?.address,
       signers: { interactiveSigner, backgroundSigner },
       chainId: chainInfo.chainId,
-      // @ts-expect-error used?
       rpc: chainInfo.rpc,
     });
   };

--- a/wallet/src/util/SuggestChain.ts
+++ b/wallet/src/util/SuggestChain.ts
@@ -20,7 +20,7 @@ export const makeChainInfo = (
   if (config?.rpc) {
     rpc = config.rpc;
   } else {
-    const rpcAddr = rpcAddrs[rpcIndex];
+    const rpcAddr = rpcAddrs[rpcIndex] ?? '';
     rpc = rpcAddr.match(/:\/\//) ? rpcAddr : `http://${rpcAddr}`;
   }
 

--- a/wallet/src/util/connections.ts
+++ b/wallet/src/util/connections.ts
@@ -26,3 +26,10 @@ export const networkConfigUrl = {
 };
 
 export type NetworkConfigSource = ReturnType<typeof networkConfigUrl.toSource>;
+
+export type ConnectionConfig = {
+  href: string;
+  api?: string;
+  rpc?: string;
+  accessToken?: string;
+};

--- a/wallet/src/util/connections.ts
+++ b/wallet/src/util/connections.ts
@@ -1,9 +1,8 @@
 export const KnownNetworkConfigUrls = {
   main: 'https://main.agoric.net/network-config',
   devnet: 'https://devnet.agoric.net/network-config',
-  testnet: 'https://testnet.agoric.net/network-config',
-  // for localhost skip https and assume it's subpathed to /wallet
-  localhost: 'http://localhost:3000/wallet/network-config',
+  testnet: 'https://emerynet.agoric.net/network-config',
+  local: `${window.location.origin}/wallet/network-config`,
 };
 
 export const DEFAULT_CONNECTION_CONFIGS = Object.values(

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,10 +108,24 @@
     "@endo/promise-kit" "^0.2.56"
     node-fetch "^2.6.0"
 
-"@agoric/cosmic-proto@0.2.2-dev-a5437cf.0", "@agoric/cosmic-proto@0.3.1-dev-ff36f02.0+ff36f02", "@agoric/cosmic-proto@^0.3.0":
+"@agoric/cosmic-proto@0.2.2-dev-a5437cf.0":
   version "0.2.2-dev-a5437cf.0"
   resolved "https://registry.yarnpkg.com/@agoric/cosmic-proto/-/cosmic-proto-0.2.2-dev-a5437cf.0.tgz#cba81f0455ba1875d3f389b69d93e36d5569bfb3"
   integrity sha512-ocwgjLUJcuKeDP7/RHWQXDqpDDCEEBqsX1JQNjmnkljE5dNkUBiDNMXurzmD+SZJqGDZ1HxaQFfF/9zo99q4vA==
+  dependencies:
+    protobufjs "^7.0.0"
+
+"@agoric/cosmic-proto@0.3.1-dev-ff36f02.0+ff36f02":
+  version "0.3.1-dev-ff36f02.0"
+  resolved "https://registry.yarnpkg.com/@agoric/cosmic-proto/-/cosmic-proto-0.3.1-dev-ff36f02.0.tgz#f6d6cf21b62e4fffbbc3c5634d3754d17d793f70"
+  integrity sha512-y266YxgI6ZN8UxqDezFjfcHTTOlo9FhFM22cN9EQVah0Z4FbNzXplYwrNRZZljGvtbb33w+oZNfv89fZ2aB5Gw==
+  dependencies:
+    protobufjs "^7.0.0"
+
+"@agoric/cosmic-proto@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@agoric/cosmic-proto/-/cosmic-proto-0.3.0.tgz#c9d31d3946c91fbb1630f89d8ba63a662bcdacc5"
+  integrity sha512-cIunby6gs53sGkHx3ALraREbfVQXvsIcObMjQQ0/tZt5HVqwoS7Y1Qj1Xl0ZZvqE8B1Zyk7QMDj829mbTII+9g==
   dependencies:
     protobufjs "^7.0.0"
 


### PR DESCRIPTION
fixes https://github.com/Agoric/wallet-app/issues/130

Adds auto-suggest inputs for rpc and api nodes. The suggestions are fetched from the currently selected network config. When the inputs are empty, it just defaults to a random node, so the inputs are not required.

## Screenshot

![image](https://github.com/Agoric/wallet-app/assets/8848650/6f25c996-c1ef-4913-b971-03ec0a3c9287)
