### PR TITLE
test: check for existence of tokens after connecting with wallet

### DIFF
--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -28,6 +28,15 @@ describe('Wallet App Test Cases', () => {
       cy.acceptAccess().then((taskCompleted) => {
         expect(taskCompleted).to.be.true;
       });
+
+      cy.reload();
+
+      cy.acceptAccess().then((taskCompleted) => {
+        expect(taskCompleted).to.be.true;
+      });
+
+      cy.get('span').contains('ATOM').should('exist');
+      cy.get('span').contains('BLD').should('exist');
     });
   });
 });


### PR DESCRIPTION
The PR adds a verification step post-wallet connection to confirm both ATOM and BLD tokens are visibly displayed on the screen.