### PR TITLE
ci: added daily scheduled run to e2e test workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   e2e:

--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -1,15 +1,11 @@
 /* eslint-disable ui-testing/no-disabled-tests */
 describe('Wallet App Test Cases', () => {
   context('Test commands', () => {
-    it(`should setup Keplr account and connect with Agoric Chain`, () => {
-      cy.setupWallet().then((setupFinished) => {
-        expect(setupFinished).to.be.true;
+    it(`should connect with Agoric Chain`, () => {
+      cy.visit('/');
 
-        cy.visit('/');
-
-        cy.acceptAccess().then((taskCompleted) => {
-          expect(taskCompleted).to.be.true;
-        });
+      cy.acceptAccess().then((taskCompleted) => {
+        expect(taskCompleted).to.be.true;
       });
     });
 


### PR DESCRIPTION
This PR adds a scheduled run the `e2e.yml` github action to run it once daily.

It also updates the tests to remove an extra call to `setupWallet`. this call is already triggered by `synpress` by default when the `SKIP_EXTENSION_SETUP` env variable is not provided. so it isn't needed here