### PR TITLE
test: add test for provisioning a brand new wallet

### DIFF
--- a/test/e2e/constants.js
+++ b/test/e2e/constants.js
@@ -1,0 +1,3 @@
+export const EMERYNET_FAUCET_URL = 'https://emerynet.faucet.agoric.net';
+export const DEFAULT_TIMEOUT = 2 * 60 * 1000;
+export const AGORIC_ADDR_RE = /agoric1.{38}/;


### PR DESCRIPTION
The PR adds a test case that involves:
- Creating a brand new wallet. 
- Obtaining funds from the faucet. 
- Provisioning the wallet. 