### PR TITLE
refactor: remove fragile selectors

### DIFF
--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -3,9 +3,11 @@ import {
   accountAddresses,
   EMERYNET_FAUCET_URL,
   DEFAULT_TIMEOUT,
+  DEFAULT_TASK_TIMEOUT,
+  DEFAULT_EXEC_TIMEOUT,
   AGORIC_ADDR_RE,
 } from '../test.utils';
-describe('Wallet App Test Cases', { execTimeout: DEFAULT_TIMEOUT }, () => {
+describe('Wallet App Test Cases', { execTimeout: DEFAULT_EXEC_TIMEOUT }, () => {
   context('Test commands', () => {
     it(`should connect with Agoric Chain`, () => {
       cy.visit('/');
@@ -101,20 +103,26 @@ describe('Wallet App Test Cases', { execTimeout: DEFAULT_TIMEOUT }, () => {
       });
     });
 
-    it('should place a bid by discount from the CLI successfully and verify IST balance', () => {
-      cy.addNewTokensFound();
-      cy.getTokenAmount('IST').then((initialTokenValue) => {
-        cy.placeBidByDiscount({
-          fromAddress: accountAddresses.user2,
-          giveAmount: '2IST',
-          discount: 5,
-        }).then(() => {
-          cy.getTokenAmount('IST').then((tokenValue) => {
-            expect(tokenValue).to.lessThan(initialTokenValue);
+    it(
+      'should place a bid by discount from the CLI successfully and verify IST balance',
+      {
+        taskTimeout: DEFAULT_TASK_TIMEOUT,
+      },
+      () => {
+        cy.addNewTokensFound();
+        cy.getTokenAmount('IST').then((initialTokenValue) => {
+          cy.placeBidByDiscount({
+            fromAddress: accountAddresses.user2,
+            giveAmount: '2IST',
+            discount: 5,
+          }).then(() => {
+            cy.getTokenAmount('IST').then((tokenValue) => {
+              expect(tokenValue).to.lessThan(initialTokenValue);
+            });
           });
         });
-      });
-    });
+      },
+    );
 
     it.skip('should view the bid from CLI', () => {
       cy.listBids(accountAddresses.user2);
@@ -144,19 +152,25 @@ describe('Wallet App Test Cases', { execTimeout: DEFAULT_TIMEOUT }, () => {
       });
     });
 
-    it('should place a bid by price from the CLI successfully and verify IST balance', () => {
-      cy.getTokenAmount('IST').then((initialTokenValue) => {
-        cy.placeBidByPrice({
-          fromAddress: accountAddresses.user2,
-          giveAmount: '1IST',
-          price: 8.55,
-        }).then(() => {
-          cy.getTokenAmount('IST').then((tokenValue) => {
-            expect(tokenValue).to.lessThan(initialTokenValue);
+    it(
+      'should place a bid by price from the CLI successfully and verify IST balance',
+      {
+        taskTimeout: DEFAULT_TASK_TIMEOUT,
+      },
+      () => {
+        cy.getTokenAmount('IST').then((initialTokenValue) => {
+          cy.placeBidByPrice({
+            fromAddress: accountAddresses.user2,
+            giveAmount: '1IST',
+            price: 8.55,
+          }).then(() => {
+            cy.getTokenAmount('IST').then((tokenValue) => {
+              expect(tokenValue).to.lessThan(initialTokenValue);
+            });
           });
         });
-      });
-    });
+      },
+    );
 
     it('should see an offer placed in the previous test case', () => {
       cy.visit('/wallet/');

--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -18,13 +18,12 @@ describe('Wallet App Test Cases', { execTimeout: DEFAULT_TIMEOUT }, () => {
     it('should setup web wallet successfully', () => {
       cy.visit('/wallet/');
 
-      cy.get('input.PrivateSwitchBase-input').click();
+      cy.get('input[type="checkbox"]').check();
       cy.contains('Proceed').click();
-
       cy.get('button[aria-label="Settings"]').click();
 
-      cy.get('#demo-simple-select').click();
-      cy.get('li[data-value="testnet"]').click();
+      cy.contains('Mainnet').click();
+      cy.contains('Emerynet').click();
       cy.contains('button', 'Connect').click();
 
       cy.acceptAccess().then((taskCompleted) => {
@@ -134,13 +133,11 @@ describe('Wallet App Test Cases', { execTimeout: DEFAULT_TIMEOUT }, () => {
     it('should cancel the bid by discount and verify IST balance', () => {
       cy.getTokenAmount('IST').then((initialTokenValue) => {
         cy.visit('/wallet/');
-        cy.get('.Controls .MuiChip-root').contains('Exit').click();
+        cy.contains('Exit').click();
         cy.acceptAccess().then((taskCompleted) => {
           expect(taskCompleted).to.be.true;
         });
-        cy.get('.Body .MuiChip-label')
-          .contains('Accepted', { timeout: DEFAULT_TIMEOUT })
-          .should('exist');
+        cy.contains('Accepted', { timeout: DEFAULT_TIMEOUT }).should('exist');
         cy.getTokenAmount('IST').then((tokenValue) => {
           expect(tokenValue).to.greaterThan(initialTokenValue);
         });
@@ -173,13 +170,11 @@ describe('Wallet App Test Cases', { execTimeout: DEFAULT_TIMEOUT }, () => {
     it('should cancel the bid by price and verify IST balance', () => {
       cy.getTokenAmount('IST').then((initialTokenValue) => {
         cy.visit('/wallet/');
-        cy.get('.Controls .MuiChip-root').contains('Exit').click();
+        cy.contains('Exit').click();
         cy.acceptAccess().then((taskCompleted) => {
           expect(taskCompleted).to.be.true;
         });
-        cy.get('.Body .MuiChip-label')
-          .contains('Accepted', { timeout: DEFAULT_TIMEOUT })
-          .should('exist');
+        cy.contains('Accepted', { timeout: DEFAULT_TIMEOUT }).should('exist');
         cy.getTokenAmount('IST').then((tokenValue) => {
           expect(tokenValue).to.greaterThan(initialTokenValue);
         });

--- a/test/e2e/synpress.config.cjs
+++ b/test/e2e/synpress.config.cjs
@@ -9,6 +9,6 @@ module.exports = defineConfig({
     specPattern: 'test/e2e/specs/**/*spec.{js,jsx,ts,tsx}',
     supportFile: 'test/e2e/support.js',
     screenshotsFolder: 'test/e2e/screenshots',
-    videosFolder: 'test/e2e/videos'
+    videosFolder: 'test/e2e/videos',
   },
 });

--- a/test/e2e/test.utils.js
+++ b/test/e2e/test.utils.js
@@ -15,7 +15,17 @@ export const accountAddresses = {
 };
 
 export const EMERYNET_FAUCET_URL = 'https://emerynet.faucet.agoric.net';
-export const DEFAULT_TIMEOUT = 2 * 60 * 1000;
+/*
+ * DEFAULT_TIMEOUT: timeout for actions involving waiting for DOM elements.
+ * DEFAULT_TASK_TIMEOUT: timeout for custom commands in support.js.
+ *
+ * Many tests use both (waiting for DOM elements and custom commands).
+ * Using both timeouts for such tests can help ensure stability,
+ * especially when running the tests with Emerynet.
+ */
+export const DEFAULT_TIMEOUT = 3 * 60 * 1000;
+export const DEFAULT_TASK_TIMEOUT = 3 * 60 * 1000;
+export const DEFAULT_EXEC_TIMEOUT = 3 * 60 * 1000;
 export const AGORIC_ADDR_RE = /agoric1.{38}/;
 export const AGORIC_NET = 'emerynet';
 


### PR DESCRIPTION
The PR does the following:
- Eliminates fragile selectors used in e2e test cases. 
- Increase timeouts for some tests to ensure stability with emerynet. 