### PR TITLE
fix: use correct agops path for e2e tests

### DIFF
--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -124,10 +124,6 @@ describe('Wallet App Test Cases', { execTimeout: DEFAULT_EXEC_TIMEOUT }, () => {
       },
     );
 
-    it.skip('should view the bid from CLI', () => {
-      cy.listBids(accountAddresses.user2);
-    });
-
     it('should see an offer placed in the previous test case', () => {
       cy.visit('/wallet/');
 
@@ -171,6 +167,10 @@ describe('Wallet App Test Cases', { execTimeout: DEFAULT_EXEC_TIMEOUT }, () => {
         });
       },
     );
+
+    it('should view the bid from CLI', () => {
+      cy.listBids(accountAddresses.user2);
+    });
 
     it('should see an offer placed in the previous test case', () => {
       cy.visit('/wallet/');

--- a/test/e2e/support.js
+++ b/test/e2e/support.js
@@ -70,6 +70,7 @@ Cypress.Commands.add('listBids', (userAddress) => {
       `${agops} inter bid list --from ${userAddress} --keyring-backend=test`,
       {
         env: { AGORIC_NET },
+        failOnNonZeroExit: false,
       },
     )
     .then(({ stdout }) => {

--- a/test/e2e/support.js
+++ b/test/e2e/support.js
@@ -1,6 +1,8 @@
 import '@agoric/synpress/support/index';
 import { AGORIC_NET, flattenObject } from './test.utils';
 
+const agops = '/usr/src/agoric-sdk/packages/agoric-cli/bin/agops';
+
 Cypress.Commands.add('addKeys', (params) => {
   const { keyName, mnemonic, expectedAddress } = params;
   const command = `echo ${mnemonic} | agd keys add ${keyName} --recover --keyring-backend=test`;
@@ -12,7 +14,7 @@ Cypress.Commands.add('addKeys', (params) => {
 
 Cypress.Commands.add('placeBidByPrice', (params) => {
   const { fromAddress, giveAmount, price } = params;
-  const command = `agops inter bid by-price --from ${fromAddress} --give ${giveAmount} --price ${price} --keyring-backend=test`;
+  const command = `${agops} inter bid by-price --from ${fromAddress} --give ${giveAmount} --price ${price} --keyring-backend=test`;
 
   cy.exec(command, { env: { AGORIC_NET } }).then(({ stdout }) => {
     expect(stdout).to.contain('Your bid has been accepted');
@@ -22,7 +24,7 @@ Cypress.Commands.add('placeBidByPrice', (params) => {
 Cypress.Commands.add('placeBidByDiscount', (params) => {
   const { fromAddress, giveAmount, discount } = params;
 
-  const command = `agops inter bid by-discount --from ${fromAddress} --give ${giveAmount} --discount ${discount} --keyring-backend=test`;
+  const command = `${agops} inter bid by-discount --from ${fromAddress} --give ${giveAmount} --discount ${discount} --keyring-backend=test`;
 
   cy.exec(command, { env: { AGORIC_NET }, failOnNonZeroExit: false }).then(
     ({ stdout }) => {
@@ -64,9 +66,12 @@ Cypress.Commands.add('checkAuctionStatus', () => {
 
 Cypress.Commands.add('listBids', (userAddress) => {
   return cy
-    .exec(`agops inter bid list --from ${userAddress} --keyring-backend=test`, {
-      env: { AGORIC_NET },
-    })
+    .exec(
+      `${agops} inter bid list --from ${userAddress} --keyring-backend=test`,
+      {
+        env: { AGORIC_NET },
+      },
+    )
     .then(({ stdout }) => {
       expect(stdout).to.contain('Your bid has been accepted');
     });


### PR DESCRIPTION
I was investigating an issue where the `agops` command worked fine when run from the terminal but gave different results when executed in my end-to-end tests. The issue was specifically with the `agops inter bid list` command.

From my understanding, this discrepancy occurred because Node.js, which runs our shell commands, looks for executables in the `bin` folder of `node_modules`. Due to some dependencies in `wallet-app`, an older version of agops was present in that `bin` folder. And as a result, the commands picked up this older version instead of the system executable for `agops`. I found this by running `type -a agops` in a test case and seeing its output:
![image](https://github.com/Agoric/wallet-app/assets/60459172/cee0de36-31a5-4848-a8e5-4bec18726530)


One potential solution is to update the dependencies of `wallet-app`, but I think this is not a permanent fix. Developers often do not actively maintain packages, leading to possible future issues.

For the reliability of our end-to-end test cases, I think it is important to run them using the latest version of the `agoric-sdk` image in our CI pipeline. This way we can be sure that our test results are consistent and compatible with the latest `agoric-sdk` updates.

For this reason, I feel specifying the exact path for `agops` in our tests is suitable and solves the problem. 