### PR TITLE
ci: change docker-compose to docker compose

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,22 +22,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - name: Run E2E Tests
         run: |
-          docker-compose -f test/e2e/docker-compose.yml --profile synpress up --build --exit-code-from synpress
+          docker compose -f test/e2e/docker-compose.yml --profile synpress up --build --exit-code-from synpress
         env:
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1


### PR DESCRIPTION
Refs: https://github.com/Agoric/dapp-econ-gov/issues/111
Fixes some flakes in e2e testing.

- Firstly used docker compose instead of docker-compose (which is not being recognized by github actions)
- Secondly removed some unnecessary steps to give some space to the github runner, otherwise the job was failing due to space limit being reached