### PR TITLE
ci: use latest agoric-sdk image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/agoric/agoric-sdk:45
+FROM ghcr.io/agoric/agoric-sdk:latest
 
 # Add the Agoric CLI to the PATH so that 'agops' can be accessed from anywhere in the command line.
 ENV PATH="/usr/src/agoric-sdk/packages/agoric-cli/bin:${PATH}"


### PR DESCRIPTION
This PR updates the `agoric-sdk` image used in CI for end-to-end tests to the latest version.