### PR TITLE
ci: adding profiles to differeniate between scheduled and PR test runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
     types:
+      - opened
+      - reopened
+      - edited
       - labeled
       - synchronize
   schedule:

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   synpress:
     profiles:
       - synpress
+      - daily-tests
     container_name: synpress
     build: ../..
     environment:
@@ -70,6 +71,7 @@ services:
   display:
     profiles:
       - synpress
+      - daily-tests
     container_name: display
     image: synthetixio/display:016121eafdfff448414894d0ca5a50b1d72b62eb-base
     environment:
@@ -98,8 +100,6 @@ services:
       - x11
 
   agd:
-    tty: false
-    stdin_open: false
     profiles:
       - synpress
     container_name: agoric_chain


### PR DESCRIPTION
The PR introduces a new profile called `daily-tests` in the Docker Compose file. Profiles are used to configure containers for scheduled runs and when testing against a PR.