### PR TITLE
URL changes in e2e tests to make it work locally

### DIFF
--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -19,7 +19,7 @@ describe('Wallet App Test Cases', { execTimeout: DEFAULT_EXEC_TIMEOUT }, () => {
       });
     });
     it(`should open the web wallet URL successfully`, () => {
-      cy.visit(`${userConfig.webwalletURL}`);
+      cy.visit('/');
 
       cy.acceptAccess().then((taskCompleted) => {
         expect(taskCompleted).to.be.true;
@@ -27,7 +27,7 @@ describe('Wallet App Test Cases', { execTimeout: DEFAULT_EXEC_TIMEOUT }, () => {
     });
 
     it('should setup web wallet successfully', () => {
-      cy.visit(`${userConfig.webwalletURL}wallet/`);
+      cy.visit('/wallet/');
 
       cy.get('input[type="checkbox"]').check();
       cy.contains('Proceed').click();
@@ -75,7 +75,7 @@ describe('Wallet App Test Cases', { execTimeout: DEFAULT_EXEC_TIMEOUT }, () => {
         cy.provisionFromFaucet(address, 'client');
       });
 
-      cy.visit(`${userConfig.webwalletURL}wallet/`);
+      cy.visit('/wallet/');
       cy.get('span').contains('ATOM').should('exist');
       cy.get('span').contains('BLD').should('exist');
     });
@@ -130,7 +130,7 @@ describe('Wallet App Test Cases', { execTimeout: DEFAULT_EXEC_TIMEOUT }, () => {
     });
 
     it('should see an offer placed in the previous test case', () => {
-      cy.visit(`${userConfig.webwalletURL}wallet/`);
+      cy.visit('/wallet/');
 
       cy.contains('Offer').should('be.visible');
       cy.contains('Give Bid').should('be.visible');
@@ -141,7 +141,7 @@ describe('Wallet App Test Cases', { execTimeout: DEFAULT_EXEC_TIMEOUT }, () => {
 
     it('should cancel the bid by discount and verify IST balance', () => {
       cy.getTokenAmount('IST').then((initialTokenValue) => {
-        cy.visit(`${userConfig.webwalletURL}wallet/`);
+        cy.visit('/wallet/');
         cy.contains('Exit').click();
         cy.acceptAccess().then((taskCompleted) => {
           expect(taskCompleted).to.be.true;
@@ -174,7 +174,7 @@ describe('Wallet App Test Cases', { execTimeout: DEFAULT_EXEC_TIMEOUT }, () => {
     );
 
     it('should see an offer placed in the previous test case', () => {
-      cy.visit(`${userConfig.webwalletURL}wallet/`);
+      cy.visit('/wallet/');
       cy.contains('Offer').should('be.visible');
       cy.contains('Give Bid').should('be.visible');
       cy.contains('1.00 IST').should('be.visible');
@@ -184,7 +184,7 @@ describe('Wallet App Test Cases', { execTimeout: DEFAULT_EXEC_TIMEOUT }, () => {
 
     it('should cancel the bid by price and verify IST balance', () => {
       cy.getTokenAmount('IST').then((initialTokenValue) => {
-        cy.visit(`${userConfig.webwalletURL}wallet/`);
+        cy.visit('/wallet/');
         cy.contains('Exit').click();
         cy.acceptAccess().then((taskCompleted) => {
           expect(taskCompleted).to.be.true;

--- a/test/e2e/test.utils.js
+++ b/test/e2e/test.utils.js
@@ -57,15 +57,12 @@ export const config = {
     userKeyName: 'user1',
     userWalletAddress: accountAddresses.user1,
     userWalletMnemonic: mnemonics.user1,
-    // UNTIL https://github.com/Agoric/wallet-app/issues/184
-    webwalletURL: 'https://wallet.agoric.app/',
     COMMAND_TIMEOUT: 2 * 60 * 1000,
   },
   testnet: {
     userKeyName: 'user2',
     userWalletAddress: accountAddresses.user2,
     userWalletMnemonic: mnemonics.user2,
-    webwalletURL: '/',
     COMMAND_TIMEOUT: 2 * 60 * 1000,
   },
 };


### PR DESCRIPTION
After updating the `ses` version in #187, the `a3p` chain is working fine with the wallet app. This PR updates the e2e tests to use the `localhost` URL when `AGORIC_NET` is `local`. 

closes #184