### PR TITLE
ci: input agoric-sdk image tag

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,6 +32,11 @@ on:
         description: 'Docker image tag for the a3p chain to use in testing'
         required: false
         type: string
+      base_image:
+        description: 'Base image tag for agoric-sdk'
+        required: false
+        default: latest
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -60,6 +65,7 @@ jobs:
         run: |
           docker compose -f test/e2e/docker-compose.yml --profile $SYNPRESS_PROFILE up --build --exit-code-from synpress
         env:
+          BASE_IMAGE_TAG_INPUT: ${{ inputs.base_image || 'latest' }}
           A3P_IMAGE_TAG: ${{ inputs.a3p_image_tag || 'latest' }}
           SYNPRESS_PROFILE: ${{ env.AGORIC_NET == 'local' && 'synpress' || 'daily-tests' }}
           COMPOSE_DOCKER_CLI_BUILD: 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ghcr.io/agoric/agoric-sdk:latest
+ARG BASE_IMAGE_TAG
+
+FROM ghcr.io/agoric/agoric-sdk:${BASE_IMAGE_TAG}
 
 # Add the Agoric CLI to the PATH so that 'agops' can be accessed from anywhere in the command line.
 ENV PATH="/usr/src/agoric-sdk/packages/agoric-cli/bin:${PATH}"

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -6,7 +6,10 @@ services:
       - synpress
       - daily-tests
     container_name: synpress
-    build: ../..
+    build:
+      context: ../..
+      args:
+        BASE_IMAGE_TAG: ${BASE_IMAGE_TAG_INPUT}
     environment:
       - DISPLAY=display:0.0
       - CYPRESS_PRIVATE_KEY_WITH_FUNDS=${CYPRESS_PRIVATE_KEY_WITH_FUNDS}


### PR DESCRIPTION
This PR enables specifying a tag value for the `agoric-sdk` image in CI, allowing end-to-end tests to run with the provided tag.