### PR TITLE
test: add wait before checking keplr popup

### DIFF
--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -40,6 +40,8 @@ describe('Wallet App Test Cases', { execTimeout: DEFAULT_EXEC_TIMEOUT }, () => {
 
       cy.contains('button', 'Connect').click();
 
+      cy.wait(5000);
+
       if (AGORIC_NET !== 'local') {
         cy.acceptAccess().then((taskCompleted) => {
           expect(taskCompleted).to.be.true;


### PR DESCRIPTION
Adding a wait of 5 seconds before trying to look for the Keplr popup. 

Seems to be passing CI at the moment. Will see how it performs in the scheduled runs in the coming days. 